### PR TITLE
feat: add publish workflow for PyPI Trusted Publishing via git tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: publish to pypi
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish_to_pypi:
+    name: publish to pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: check build artifact existence
+        uses: softwareforgood/check-artifact-v4-existence@v0
+        id: check_artifact_exists
+        with:
+          name: build
+
+      - name: validate artifact availability
+        if: ${{ steps.check_artifact_exists.outputs.exists != 'true' }}
+        run: |
+          echo "::error::[PyPI] Build artifact 'build' not found"
+          echo "::error::[PyPI] Expected artifact at: dist"
+          echo "::error::[PyPI] This usually means the build step failed or didn't produce artifacts"
+          exit 1
+
+      - name: download build artifact
+        if: ${{ steps.check_artifact_exists.outputs.exists == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: build
+          path: dist
+
+      - uses: astral-sh/setup-uv@v7
+        if: ${{ success() }}
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/setup-python@v6
+        if: ${{ success() }}
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: publish to pypi
+        if: ${{ success() }}
+        run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.1"
+version="2.0.2"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` triggered on `v*` tag push
- Downloads the build artifact and publishes to PyPI via OIDC Trusted Publishing
- Depends on `tehw0lf/workflows` PR #46 being merged first (reusable workflow now sets the git tag instead of publishing directly)
- **Do not merge until PyPI Trusted Publishing is configured for this repo and workflows PR #46 is merged**

## Test plan
- [x] Merge tehw0lf/workflows#46
- [x] Configure PyPI Trusted Publishing: publisher = `tehw0lf/wlgen`, workflow = `publish.yml`
- [ ] Merge this PR and verify the tag-triggered publish runs successfully