### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,5 @@ jobs:
       build_main: "build"
       artifact_path: "dist"
       publish_github_release: "true"
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.2"
+version="2.0.3"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Version bump to test PyPI Trusted Publishing via git tag trigger.