### PR TITLE
refactor: switch publish trigger to workflow_run, remove GH_PAT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,5 @@ jobs:
       build_main: "build"
       artifact_path: "dist"
       publish_github_release: "true"
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,3 @@ jobs:
       build_main: "build"
       artifact_path: "dist"
       publish_github_release: "true"
-    secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,16 @@
 name: publish to pypi
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["build pipeline"]
+    types: [completed]
+    branches: [main]
 
 jobs:
   publish_to_pypi:
     name: publish to pypi
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 15
     permissions:
       actions: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.2"
+version="2.0.3"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Switches `publish.yml` trigger from `on: push: tags` to `on: workflow_run` after successful build pipeline on main
- Removes `GH_PAT` secret — no longer needed since OIDC runs directly in this repo's context
- Also removes `GH_PAT` passthrough from `build.yml`

## Note
The GH_PAT secret in wlgen repo settings and the corresponding changes in tehw0lf/workflows can be cleaned up after this is confirmed working.