### PR TITLE
chore: bump version to 2.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.3"
+version="2.0.4"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Version bump to test PyPI Trusted Publishing via workflow_run.