### PR TITLE
fix: download artifact from triggering workflow run, bump to 2.0.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,26 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: check build artifact existence
-        uses: softwareforgood/check-artifact-v4-existence@v0
-        id: check_artifact_exists
-        with:
-          name: build
-
-      - name: validate artifact availability
-        if: ${{ steps.check_artifact_exists.outputs.exists != 'true' }}
-        run: |
-          echo "::error::[PyPI] Build artifact 'build' not found"
-          echo "::error::[PyPI] Expected artifact at: dist"
-          echo "::error::[PyPI] This usually means the build step failed or didn't produce artifacts"
-          exit 1
-
       - name: download build artifact
-        if: ${{ steps.check_artifact_exists.outputs.exists == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: build
           path: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: astral-sh/setup-uv@v7
         if: ${{ success() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.4"
+version="2.0.5"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Fixes artifact download in `publish.yml` by passing `run-id` from the triggering workflow run
- Bumps version to 2.0.5