### PR TITLE
fix(ci): add pull-requests: write permission to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,4 @@ jobs:
       build_main: "build"
       artifact_path: "dist"
       publish_github_release: "true"
+      publish_python_libraries: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       packages: write
       security-events: write
+      pull-requests: write
     with:
       tool: "uv"
       install: "sync --all-extras --group lint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="wlgen"
-version="2.0.5"
+version="2.0.6"
 description="A recursive wordlist generator written in python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "wlgen"
-version = "2.0.5"
+version = "2.0.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to the reusable workflow call

## Reason
All repos using reusable workflows from `tehw0lf/workflows` require `pull-requests: write` to function correctly, regardless of the build tool used.